### PR TITLE
Feat/ma salt

### DIFF
--- a/packages/core/accounts/impl.ts
+++ b/packages/core/accounts/impl.ts
@@ -34,11 +34,12 @@ export async function createLockerClient(
 ): Promise<ILockerClient> {
   validateClientParams(params);
 
-  const { alchemyApiKey: apiKey, chain: lockerChain, signer } = params;
+  const { alchemyApiKey: apiKey, chain: lockerChain, signer, salt } = params;
 
   const chain = adaptLockerChain2AlchemyChain(lockerChain);
 
   const aaClient = await createModularAccountAlchemyClient({
+    salt: salt ? salt : BigInt(0),
     signer,
     chain,
     transport: alchemy({ apiKey }),

--- a/packages/core/accounts/types.ts
+++ b/packages/core/accounts/types.ts
@@ -3,10 +3,11 @@ import { LocalAccountSigner } from "@aa-sdk/core";
 import type { EChain } from "tokens";
 
 export interface ILockerClientParams {
-    alchemyApiKey: string; // Used for the Alchemy transport.
-    chain: EChain;
-    signer: ReturnType<typeof LocalAccountSigner.privateKeyToAccountSigner>;
-    merchantSeed1?: string;
+  alchemyApiKey: string; // Used for the Alchemy transport.
+  chain: EChain;
+  signer: ReturnType<typeof LocalAccountSigner.privateKeyToAccountSigner>;
+  merchantSeed1?: string;
+  salt?: bigint;
 }
 
 export enum EPlugins {

--- a/packages/core/plugins/utils/helpers.ts
+++ b/packages/core/plugins/utils/helpers.ts
@@ -6,7 +6,6 @@ async function isSplitPluginInstalled(
 ): Promise<boolean> {
   const splitPluginAddress = chainToSplitPluginAddress[chainId];
   const installedPlugins = await extendedAccount.getInstalledPlugins({});
-  console.log('Installed plugins:', installedPlugins);
   if (!installedPlugins.includes(splitPluginAddress)) {
     return false;
   }

--- a/packages/examples/bridge-and-split/index.ts
+++ b/packages/examples/bridge-and-split/index.ts
@@ -63,9 +63,12 @@ const bridgeName: IBridgeName = "cctp";
 
 // Create a Locker Client
 const splitClient = await createLockerSplitClient({
+  salt: BigInt(1),
   alchemyApiKey,
   chain: recipientChain,
-  signer: LocalAccountSigner.privateKeyToAccountSigner(evmPrivateKey as Address),
+  signer: LocalAccountSigner.privateKeyToAccountSigner(
+    evmPrivateKey as Address
+  ),
 });
 
 // Get address for the Locker Client. This is the address that will receive the token then split it.
@@ -73,7 +76,6 @@ const recipientAddress = splitClient.getAddress();
 console.log(`Recipient address: ${recipientAddress}`);
 
 async function bridgeAndSplit() {
-
   // One time connfiguration of Locker Client
   const pluginInstalled = await splitClient.isSplitPluginInstalled();
   if (!pluginInstalled) {
@@ -83,7 +85,11 @@ async function bridgeAndSplit() {
 
     // 2. create split config
     console.log("Creating split config");
-    await splitClient.createSplit(recipientChainToken, splitPercentages, splitRecipients);
+    await splitClient.createSplit(
+      recipientChainToken,
+      splitPercentages,
+      splitRecipients
+    );
   } else {
     console.log("Split Plugin already installed");
   }
@@ -115,8 +121,12 @@ async function bridgeAndSplit() {
 }
 
 async function cleanup() {
-  // Cleanup: uninstall split plugin and delete split config
-  await splitClient.deleteSplit(0);
+  // Cleanup: uninstall split plugin and delete split configs
+  const configIndexes = await splitClient.getConfigs();
+  for (const index of configIndexes) {
+    await splitClient.deleteSplit(index);
+  }
+
   await splitClient.uninstallSplitPlugin();
 }
 


### PR DESCRIPTION
- The createLockerClient parameters now expect a salt which will enable a single signer to generate multiple ma accounts.
- Updated the deleteSplit function, it still doesn't work every time so excluding cleanup in the main example file.