### PR TITLE
Feat/install split

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,6 +7,8 @@ This repository contains the smart contracts for Locker Labs. The Split Plugin, 
 ### Split Plugin
 Allows users to split token transfers among multiple recipients automatically, simplifying fund distribution.
 
-- Base: [0x981656a00aB861498E2DCE2a94b1dd416B684844](https://basescan.org/address/0x981656a00aB861498E2DCE2a94b1dd416B684844)
+- Base: [0x3e71215c32095fd32c458E683D557709c3cef2f9](https://basescan.org/address/0x981656a00aB861498E2DCE2a94b1dd416B684844)
 
-- Sepolia: [0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317](https://sepolia.etherscan.io/address/0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317)
+- Sepolia: [0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC](https://sepolia.etherscan.io/address/0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317)
+
+- Base Sepolia: [0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7](https://base-sepolia.blockscout.com/address/0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7)

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,8 +7,8 @@ This repository contains the smart contracts for Locker Labs. The Split Plugin, 
 ### Split Plugin
 Allows users to split token transfers among multiple recipients automatically, simplifying fund distribution.
 
-- Base: [0x3e71215c32095fd32c458E683D557709c3cef2f9](https://basescan.org/address/0x981656a00aB861498E2DCE2a94b1dd416B684844)
+- Base: [0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4](https://basescan.org/address/0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4)
 
-- Sepolia: [0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC](https://sepolia.etherscan.io/address/0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317)
+- Sepolia: [0x12438c60e855ca58C34b1b2780d208D733D370CF](https://sepolia.etherscan.io/address/0x12438c60e855ca58C34b1b2780d208D733D370CF)
 
-- Base Sepolia: [0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7](https://base-sepolia.blockscout.com/address/0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7)
+- Base Sepolia: [0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b](https://base-sepolia.blockscout.com/address/0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b)

--- a/contracts/src/plugins/split/SplitPlugin.sol
+++ b/contracts/src/plugins/split/SplitPlugin.sol
@@ -52,7 +52,7 @@ contract SplitPlugin is BasePlugin {
 
     /// @dev Creates a split configuration for the user
     function createSplit(address _tokenAddress, address[] memory _splitAddresses, uint32[] memory _percentages)
-        external
+        public
     {
         require(_splitAddresses.length > 0, "SplitPlugin: No split addresses provided");
         require(_splitAddresses.length < MAX_TOKEN_CONFIGS, "SplitPlugin: Split addresses limit exceeded");
@@ -164,9 +164,20 @@ contract SplitPlugin is BasePlugin {
         return isCreator;
     }
 
-    function onInstall(bytes calldata _data) external pure override {}
+    /// @dev Returns the split config indexes for the user
+    function getSplitIndexes(address _user) external view returns (uint256[] memory) {
+        return splitConfigIndexes[_user];
+    }
 
-    function onUninstall(bytes calldata) external override {}
+    function _onInstall(bytes calldata data) internal override {
+        (address tokenAddress, address[] memory splitAddresses, uint32[] memory percentages) =
+            abi.decode(data, (address, address[], uint32[]));
+        createSplit(tokenAddress, splitAddresses, percentages);
+    }
+
+    function onUninstall(bytes calldata) external override {
+        delete splitConfigIndexes[msg.sender];
+    }
 
     function postExecutionHook(uint8, bytes calldata) external virtual override {
         uint256[] memory configIndexes = splitConfigIndexes[msg.sender];

--- a/contracts/src/plugins/split/SplitPlugin.sol
+++ b/contracts/src/plugins/split/SplitPlugin.sol
@@ -103,7 +103,7 @@ contract SplitPlugin is BasePlugin {
         SplitConfig memory config = splitConfigs[_configIndex];
         IERC20 token = IERC20(config.tokenAddress);
         uint256 totalSplitAmount = token.balanceOf(address(msg.sender));
-        if (!config.isSplitEnabled || config.minTokenAmount < totalSplitAmount) {
+        if (!config.isSplitEnabled || config.minTokenAmount > totalSplitAmount) {
             return;
         } 
 

--- a/packages/core/plugins/defs/split/abi.ts
+++ b/packages/core/plugins/defs/split/abi.ts
@@ -42,6 +42,20 @@ export const SplitPluginAbi = [
   },
   {
     type: "function",
+    name: "getSplitConfig",
+    inputs: [
+      { name: "_configIndex", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "tokenAddress", type: "address", internalType: "address" },
+      { name: "splitAddresses", type: "address[]", internalType: "address[]" },
+      { name: "percentages", type: "uint32[]", internalType: "uint32[]" },
+      { name: "isSplitEnabled", type: "bool", internalType: "bool" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "getSplitIndexes",
     inputs: [{ name: "_user", type: "address", internalType: "address" }],
     outputs: [{ name: "", type: "uint256[]", internalType: "uint256[]" }],

--- a/packages/core/plugins/defs/split/abi.ts
+++ b/packages/core/plugins/defs/split/abi.ts
@@ -26,7 +26,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -42,6 +42,13 @@ export const SplitPluginAbi = [
   },
   {
     type: "function",
+    name: "getSplitIndexes",
+    inputs: [{ name: "_user", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256[]", internalType: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "isSplitCreator",
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
@@ -53,9 +60,9 @@ export const SplitPluginAbi = [
   {
     type: "function",
     name: "onInstall",
-    inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
+    inputs: [{ name: "data", type: "bytes", internalType: "bytes" }],
     outputs: [],
-    stateMutability: "pure",
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -462,7 +469,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/core/plugins/defs/split/config.ts
+++ b/packages/core/plugins/defs/split/config.ts
@@ -1,17 +1,17 @@
 import type { PluginConfig } from "@account-kit/plugingen";
-import { type Address } from "viem";
+import { type Address, parseAbiParameters } from "viem";
 import { base, baseSepolia, sepolia } from "viem/chains";
 import { MultiOwnerPluginGenConfig } from "../multi-owner/config.js";
 import { SplitPluginAbi } from "./abi.js";
 
 export const SPLIT_PLUGIN_SEPOLIA =
-  "0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317" as Address;
+  "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address;
 
 export const SPLIT_PLUGIN_BASE =
-  "0x981656a00aB861498E2DCE2a94b1dd416B684844" as Address;
+  "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address;
 
 export const SPLIT_PLUGIN_BASE_SEPOLIA =
-  "0x9fBc03780c1AAc814E6BAD2C35Af4f55fCb31D69" as Address;
+  "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address;
 
 export const chainToSplitPluginAddress: Record<number, Address> = {
   [sepolia.id]: SPLIT_PLUGIN_SEPOLIA,
@@ -28,7 +28,9 @@ export const SplitPluginGenConfig: PluginConfig = {
     [baseSepolia.id]: SPLIT_PLUGIN_BASE_SEPOLIA,
   },
   installConfig: {
-    initAbiParams: [],
+    initAbiParams: parseAbiParameters(
+      "address tokenAddess, address[] splitAddresses, uint256[] percentages"
+    ),
 
     dependencies: [
       {

--- a/packages/core/plugins/defs/split/config.ts
+++ b/packages/core/plugins/defs/split/config.ts
@@ -5,13 +5,13 @@ import { MultiOwnerPluginGenConfig } from "../multi-owner/config.js";
 import { SplitPluginAbi } from "./abi.js";
 
 export const SPLIT_PLUGIN_SEPOLIA =
-  "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address;
+  "0x12438c60e855ca58C34b1b2780d208D733D370CF" as Address;
 
 export const SPLIT_PLUGIN_BASE =
-  "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address;
+  "0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4" as Address;
 
 export const SPLIT_PLUGIN_BASE_SEPOLIA =
-  "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address;
+  "0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b" as Address;
 
 export const chainToSplitPluginAddress: Record<number, Address> = {
   [sepolia.id]: SPLIT_PLUGIN_SEPOLIA,

--- a/packages/core/plugins/gens/base/split/plugin.ts
+++ b/packages/core/plugins/gens/base/split/plugin.ts
@@ -108,7 +108,11 @@ type ExecutionActions<
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
-type InstallArgs = [];
+type InstallArgs = [
+  { type: "address"; name: "tokenAddess" },
+  { type: "address[]"; name: "splitAddresses" },
+  { type: "uint256[]"; name: "percentages" },
+];
 
 export type InstallSplitPluginParams = {
   args: Parameters<typeof encodeAbiParameters<InstallArgs>>[1];
@@ -198,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x981656a00aB861498E2DCE2a94b1dd416B684844" as Address,
-  84532: "0x9fBc03780c1AAc814E6BAD2C35Af4f55fCb31D69" as Address,
-  11155111: "0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317" as Address,
+  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
+  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
+  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -387,7 +391,14 @@ export const splitPluginActions: <
 
     return installPlugin_(client, {
       pluginAddress,
-      pluginInitData: encodeAbiParameters([], params.args),
+      pluginInitData: encodeAbiParameters(
+        [
+          { type: "address", name: "tokenAddess" },
+          { type: "address[]", name: "splitAddresses" },
+          { type: "uint256[]", name: "percentages" },
+        ],
+        params.args,
+      ),
       dependencies,
       overrides,
       account,
@@ -438,7 +449,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -467,7 +478,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -511,7 +522,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -527,6 +538,13 @@ export const SplitPluginAbi = [
   },
   {
     type: "function",
+    name: "getSplitIndexes",
+    inputs: [{ name: "_user", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256[]", internalType: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "isSplitCreator",
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
@@ -538,9 +556,9 @@ export const SplitPluginAbi = [
   {
     type: "function",
     name: "onInstall",
-    inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
+    inputs: [{ name: "data", type: "bytes", internalType: "bytes" }],
     outputs: [],
-    stateMutability: "pure",
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -947,7 +965,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/core/plugins/gens/base/split/plugin.ts
+++ b/packages/core/plugins/gens/base/split/plugin.ts
@@ -202,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
-  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
-  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
+  8453: "0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4" as Address,
+  84532: "0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b" as Address,
+  11155111: "0x12438c60e855ca58C34b1b2780d208D733D370CF" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -535,6 +535,20 @@ export const SplitPluginAbi = [
     ],
     outputs: [],
     stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getSplitConfig",
+    inputs: [
+      { name: "_configIndex", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "tokenAddress", type: "address", internalType: "address" },
+      { name: "splitAddresses", type: "address[]", internalType: "address[]" },
+      { name: "percentages", type: "uint32[]", internalType: "uint32[]" },
+      { name: "isSplitEnabled", type: "bool", internalType: "bool" },
+    ],
+    stateMutability: "view",
   },
   {
     type: "function",

--- a/packages/core/plugins/gens/baseSepolia/split/plugin.ts
+++ b/packages/core/plugins/gens/baseSepolia/split/plugin.ts
@@ -108,7 +108,11 @@ type ExecutionActions<
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
-type InstallArgs = [];
+type InstallArgs = [
+  { type: "address"; name: "tokenAddess" },
+  { type: "address[]"; name: "splitAddresses" },
+  { type: "uint256[]"; name: "percentages" },
+];
 
 export type InstallSplitPluginParams = {
   args: Parameters<typeof encodeAbiParameters<InstallArgs>>[1];
@@ -198,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x981656a00aB861498E2DCE2a94b1dd416B684844" as Address,
-  84532: "0x9fBc03780c1AAc814E6BAD2C35Af4f55fCb31D69" as Address,
-  11155111: "0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317" as Address,
+  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
+  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
+  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -387,7 +391,14 @@ export const splitPluginActions: <
 
     return installPlugin_(client, {
       pluginAddress,
-      pluginInitData: encodeAbiParameters([], params.args),
+      pluginInitData: encodeAbiParameters(
+        [
+          { type: "address", name: "tokenAddess" },
+          { type: "address[]", name: "splitAddresses" },
+          { type: "uint256[]", name: "percentages" },
+        ],
+        params.args,
+      ),
       dependencies,
       overrides,
       account,
@@ -438,7 +449,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -467,7 +478,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -511,7 +522,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -527,6 +538,13 @@ export const SplitPluginAbi = [
   },
   {
     type: "function",
+    name: "getSplitIndexes",
+    inputs: [{ name: "_user", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256[]", internalType: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "isSplitCreator",
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
@@ -538,9 +556,9 @@ export const SplitPluginAbi = [
   {
     type: "function",
     name: "onInstall",
-    inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
+    inputs: [{ name: "data", type: "bytes", internalType: "bytes" }],
     outputs: [],
-    stateMutability: "pure",
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -947,7 +965,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/core/plugins/gens/baseSepolia/split/plugin.ts
+++ b/packages/core/plugins/gens/baseSepolia/split/plugin.ts
@@ -202,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
-  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
-  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
+  8453: "0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4" as Address,
+  84532: "0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b" as Address,
+  11155111: "0x12438c60e855ca58C34b1b2780d208D733D370CF" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -535,6 +535,20 @@ export const SplitPluginAbi = [
     ],
     outputs: [],
     stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getSplitConfig",
+    inputs: [
+      { name: "_configIndex", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "tokenAddress", type: "address", internalType: "address" },
+      { name: "splitAddresses", type: "address[]", internalType: "address[]" },
+      { name: "percentages", type: "uint32[]", internalType: "uint32[]" },
+      { name: "isSplitEnabled", type: "bool", internalType: "bool" },
+    ],
+    stateMutability: "view",
   },
   {
     type: "function",

--- a/packages/core/plugins/gens/sepolia/split/plugin.ts
+++ b/packages/core/plugins/gens/sepolia/split/plugin.ts
@@ -108,7 +108,11 @@ type ExecutionActions<
   ) => Promise<SendUserOperationResult<TEntryPointVersion>>;
 };
 
-type InstallArgs = [];
+type InstallArgs = [
+  { type: "address"; name: "tokenAddess" },
+  { type: "address[]"; name: "splitAddresses" },
+  { type: "uint256[]"; name: "percentages" },
+];
 
 export type InstallSplitPluginParams = {
   args: Parameters<typeof encodeAbiParameters<InstallArgs>>[1];
@@ -198,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x981656a00aB861498E2DCE2a94b1dd416B684844" as Address,
-  84532: "0x9fBc03780c1AAc814E6BAD2C35Af4f55fCb31D69" as Address,
-  11155111: "0x1ef5f1E4d06AD60e9A3FD64D00782c21523F7317" as Address,
+  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
+  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
+  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -387,7 +391,14 @@ export const splitPluginActions: <
 
     return installPlugin_(client, {
       pluginAddress,
-      pluginInitData: encodeAbiParameters([], params.args),
+      pluginInitData: encodeAbiParameters(
+        [
+          { type: "address", name: "tokenAddess" },
+          { type: "address[]", name: "splitAddresses" },
+          { type: "uint256[]", name: "percentages" },
+        ],
+        params.args,
+      ),
       dependencies,
       overrides,
       account,
@@ -438,7 +449,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -467,7 +478,7 @@ export const SplitPluginExecutionFunctionAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -511,7 +522,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_tokenAddress", type: "address", internalType: "address" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",
@@ -527,6 +538,13 @@ export const SplitPluginAbi = [
   },
   {
     type: "function",
+    name: "getSplitIndexes",
+    inputs: [{ name: "_user", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "uint256[]", internalType: "uint256[]" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "isSplitCreator",
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
@@ -538,9 +556,9 @@ export const SplitPluginAbi = [
   {
     type: "function",
     name: "onInstall",
-    inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
+    inputs: [{ name: "data", type: "bytes", internalType: "bytes" }],
     outputs: [],
-    stateMutability: "pure",
+    stateMutability: "nonpayable",
   },
   {
     type: "function",
@@ -947,7 +965,7 @@ export const SplitPluginAbi = [
     inputs: [
       { name: "_configIndex", type: "uint256", internalType: "uint256" },
       { name: "_splitAddresses", type: "address[]", internalType: "address[]" },
-      { name: "_percentages", type: "uint8[]", internalType: "uint8[]" },
+      { name: "_percentages", type: "uint32[]", internalType: "uint32[]" },
     ],
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/core/plugins/gens/sepolia/split/plugin.ts
+++ b/packages/core/plugins/gens/sepolia/split/plugin.ts
@@ -202,9 +202,9 @@ export type SplitPluginActions<
   ReadAndEncodeActions;
 
 const addresses = {
-  8453: "0x3e71215c32095fd32c458E683D557709c3cef2f9" as Address,
-  84532: "0x1F851DE0e959ad33193e5449EC4C23A66eAdbCC7" as Address,
-  11155111: "0x6edeB1ee954744512A1928B13e7C3Ce5D8Ad84fC" as Address,
+  8453: "0x2a4f50188850660D2C7D411EdA120CBb5D9A3EE4" as Address,
+  84532: "0x400932DCddAc89bEA6F2C261dA7aC1C427BdBf5b" as Address,
+  11155111: "0x12438c60e855ca58C34b1b2780d208D733D370CF" as Address,
 } as Record<number, Address>;
 
 export const SplitPlugin: Plugin<typeof SplitPluginAbi> = {
@@ -535,6 +535,20 @@ export const SplitPluginAbi = [
     ],
     outputs: [],
     stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getSplitConfig",
+    inputs: [
+      { name: "_configIndex", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [
+      { name: "tokenAddress", type: "address", internalType: "address" },
+      { name: "splitAddresses", type: "address[]", internalType: "address[]" },
+      { name: "percentages", type: "uint32[]", internalType: "uint32[]" },
+      { name: "isSplitEnabled", type: "bool", internalType: "bool" },
+    ],
+    stateMutability: "view",
   },
   {
     type: "function",

--- a/packages/core/plugins/index.ts
+++ b/packages/core/plugins/index.ts
@@ -20,13 +20,13 @@ export interface ILockerSplitClient extends ILockerClient {
 
   createSplit: (
     tokenAddress: Address,
-    percentage: number[],
+    percentage: bigint[],
     receiverAddresses: Address[]
   ) => Promise<any>;
 
   installSplitPlugin: (
     tokenAddress: Address,
-    percentages: number[],
+    percentages: bigint[],
     receiverAddresses: Address[]
   ) => Promise<any>;
 
@@ -108,7 +108,7 @@ export async function createLockerSplitClient(
     },
     async createSplit(
       tokenAddress: string,
-      percentage: number[],
+      percentage: bigint[],
       receiverAddresses: string[]
     ): Promise<any> {
       if (!(await isSplitPluginInstalled(splitLockerClient, chainId))) {

--- a/packages/examples/bridge-and-split/index.ts
+++ b/packages/examples/bridge-and-split/index.ts
@@ -42,7 +42,7 @@ if (!alchemyApiKey) {
 
 // Bridge config
 const sourceChain = EChain.SOLANA_DEVNET;
-const recipientChain = EChain.SEPOLIA;
+const recipientChain = EChain.BASE_SEPOLIA;
 const usdcAmount = 10000; // 0.01 USDC
 
 // Split config
@@ -50,7 +50,7 @@ const splitRecipients = [
   "0xd7F723f8EDeC8D6D62caa4Ecc2b5Ca1292618355",
   "0x1ECF3f51A771983C150b3cB4A2162E89c0A046Fc",
 ] as Address[];
-const splitPercentages = [9500000, 500000]; // Recipient 0 gets 95%, Recipient 1 gets 5%
+const splitPercentages = [BigInt(9500000), BigInt(500000)]; // Recipient 0 gets 95%, Recipient 1 gets 5%
 
 /*
  * Implementation
@@ -62,7 +62,7 @@ const bridgeName: IBridgeName = "cctp";
 
 // Create a Locker Client
 const splitClient = await createLockerSplitClient({
-  salt: BigInt(1),
+  salt: BigInt(0),
   alchemyApiKey,
   chain: recipientChain,
   signer: LocalAccountSigner.privateKeyToAccountSigner(
@@ -114,5 +114,5 @@ async function cleanup() {
   await splitClient.uninstallSplitPlugin();
 }
 
-// await bridgeAndSplit();
-await cleanup();
+await bridgeAndSplit();
+// await cleanup();

--- a/packages/examples/bridge-and-split/index.ts
+++ b/packages/examples/bridge-and-split/index.ts
@@ -42,15 +42,15 @@ if (!alchemyApiKey) {
 
 // Bridge config
 const sourceChain = EChain.SOLANA_DEVNET;
-const recipientChain = EChain.BASE_SEPOLIA;
+const recipientChain = EChain.SEPOLIA;
 const usdcAmount = 10000; // 0.01 USDC
 
 // Split config
 const splitRecipients = [
   "0xd7F723f8EDeC8D6D62caa4Ecc2b5Ca1292618355",
-  "0x1ECF3f51A771983C150b3cB4A2162E89c0A046Fc"
+  "0x1ECF3f51A771983C150b3cB4A2162E89c0A046Fc",
 ] as Address[];
-const splitPercentages = [95, 5];
+const splitPercentages = [9500000, 500000]; // Recipient 0 gets 95%, Recipient 1 gets 5%
 
 /*
  * Implementation
@@ -62,7 +62,6 @@ const bridgeName: IBridgeName = "cctp";
 
 // Create a Locker Client
 const splitClient = await createLockerSplitClient({
-  salt: BigInt(1),
   alchemyApiKey,
   chain: recipientChain,
   signer: LocalAccountSigner.privateKeyToAccountSigner(
@@ -70,12 +69,14 @@ const splitClient = await createLockerSplitClient({
   ),
 });
 
+// console.log(await splitClient.installedPlugins({}));
+
 // Get address for the Locker Client. This is the address that will receive the token then split it.
 const recipientAddress = splitClient.getAddress();
 console.log(`Recipient address: ${recipientAddress}`);
 
 // One time configuration of Locker Split Client
-await splitClient.setupSplit(
+await splitClient.installSplitPlugin(
   recipientChainToken,
   splitPercentages,
   splitRecipients
@@ -109,14 +110,8 @@ async function bridgeAndSplit() {
 }
 
 async function cleanup() {
-  // Cleanup: uninstall split plugin and delete split configs
-  const configIndexes = await splitClient.getConfigs();
-  for (const index of configIndexes) {
-    await splitClient.deleteSplit(index);
-  }
-
   await splitClient.uninstallSplitPlugin();
 }
 
-await bridgeAndSplit();
-// await cleanup();
+// await bridgeAndSplit();
+await cleanup();

--- a/packages/examples/bridge-and-split/index.ts
+++ b/packages/examples/bridge-and-split/index.ts
@@ -62,6 +62,7 @@ const bridgeName: IBridgeName = "cctp";
 
 // Create a Locker Client
 const splitClient = await createLockerSplitClient({
+  salt: BigInt(1),
   alchemyApiKey,
   chain: recipientChain,
   signer: LocalAccountSigner.privateKeyToAccountSigner(


### PR DESCRIPTION
#### `SplitPlugin.sol`
- Removed `onInstall` override and implemented `_onInstall` in SplitPlugin.sol to allow creating a split config on installation. 
- Added utility functions: `getSplitIndexes` and `getSplitConfig`
- Added `minTokenLimit` field in SplitConfig structure. This limit is needed to ensure "correct" splits, meaning to avoid 1% errors due to integer division. 

#### `packages/core/`
- Regenerated plugins for all chains 
- Updated splitClient for onInstall


#### `examples/bridge-and-split`
- Updated example for using the new build version 